### PR TITLE
Fixed #4 (Allow for custom metrics)

### DIFF
--- a/ridley-extras/LICENSE
+++ b/ridley-extras/LICENSE
@@ -1,0 +1,30 @@
+Copyright Author name here (c) 2017
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ridley-extras/README.md
+++ b/ridley-extras/README.md
@@ -1,1 +1,7 @@
 # ridley-extras
+
+A collection of useful `CustomMetric` which don't belong to the main `ridley` package.
+
+## What's included
+
+* (Linux-only) Monitor open file descriptors;

--- a/ridley-extras/README.md
+++ b/ridley-extras/README.md
@@ -1,0 +1,1 @@
+# ridley-extras

--- a/ridley-extras/README.md
+++ b/ridley-extras/README.md
@@ -4,4 +4,4 @@ A collection of useful `CustomMetric` which don't belong to the main `ridley` pa
 
 ## What's included
 
-* (Linux-only) Monitor open file descriptors;
+* Monitor open file descriptors;

--- a/ridley-extras/Setup.hs
+++ b/ridley-extras/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/ridley-extras/app/Main.hs
+++ b/ridley-extras/app/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Lib
+
+main :: IO ()
+main = someFunc

--- a/ridley-extras/ridley-extras.cabal
+++ b/ridley-extras/ridley-extras.cabal
@@ -1,0 +1,47 @@
+name:                ridley-extras
+version:             0.1.0.0
+-- synopsis:
+-- description:
+homepage:            https://github.com/githubuser/ridley-extras#readme
+license:             BSD3
+license-file:        LICENSE
+author:              Author name here
+maintainer:          example@example.com
+copyright:           2017 Author name here
+category:            Web
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+flag lib-Werror
+     default: False
+     description: Enable -Werror
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     System.Metrics.Prometheus.Ridley.Metrics.FD
+  build-depends:       base >= 4.7 && < 5,
+                       text,
+                       prometheus < 0.5.0.0,
+                       shelly < 1.7.0.0,
+                       microlens,
+                       ekg-prometheus-adapter < 0.2.0.0,
+                       mtl,
+                       transformers,
+                       ridley < 0.4.0.0
+  if flag(lib-Werror)
+    ghc-options: -Wall -Werror
+  default-language:    Haskell2010
+
+test-suite ridley-extras-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , ridley-extras
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/githubuser/ridley-extras

--- a/ridley-extras/src/System/Metrics/Prometheus/Ridley/Metrics/FD.hs
+++ b/ridley-extras/src/System/Metrics/Prometheus/Ridley/Metrics/FD.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module System.Metrics.Prometheus.Ridley.Metrics.FD where
 
 import           Control.Monad.Reader (ask)
@@ -27,7 +28,11 @@ getOpenFD pid = do
 --------------------------------------------------------------------------------
 updateOpenFD :: ProcessID -> P.Gauge -> Bool -> IO ()
 updateOpenFD pid gauge _ = do
+#ifdef darwin_HOST_OS
+  openFd <- return 0
+#else
   openFd <- getOpenFD pid
+#endif
   P.set openFd gauge
 
 --------------------------------------------------------------------------------

--- a/ridley-extras/src/System/Metrics/Prometheus/Ridley/Metrics/FD.hs
+++ b/ridley-extras/src/System/Metrics/Prometheus/Ridley/Metrics/FD.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+module System.Metrics.Prometheus.Ridley.Metrics.FD where
+
+import           Control.Monad.Reader (ask)
+import           Control.Monad.Trans.Class (lift)
+import           Data.Maybe (fromMaybe)
+import           Data.Monoid
+import qualified Data.Text as T
+import           Lens.Micro
+import           Shelly
+import qualified System.Metrics.Prometheus.Metric.Gauge as P
+import qualified System.Metrics.Prometheus.RegistryT as P
+import           System.Metrics.Prometheus.Ridley.Types
+import           System.Posix.Types (ProcessID)
+import           System.Remote.Monitoring.Prometheus (labels)
+import           Text.Read (readMaybe)
+
+--------------------------------------------------------------------------------
+getOpenFD :: ProcessID -> IO Double
+getOpenFD pid = do
+  rawOutput <- shelly $ silently $ escaping False $
+    T.strip <$> run "ls" ["-l", "/proc/" <> T.pack (show pid) <> "/fd", "|"
+                         ,"wc", "-l"
+                         ]
+  return $ fromMaybe 0.0 (readMaybe . T.unpack $ rawOutput)
+
+--------------------------------------------------------------------------------
+updateOpenFD :: ProcessID -> P.Gauge -> Bool -> IO ()
+updateOpenFD pid gauge _ = do
+  openFd <- getOpenFD pid
+  P.set openFd gauge
+
+--------------------------------------------------------------------------------
+-- | Monitors the number of open file descriptors for a given `ProcessID`.
+processOpenFD :: ProcessID -> Ridley RidleyMetricHandler
+processOpenFD pid = do
+  opts <- ask
+  let popts = opts ^. prometheusOptions
+  openFD <- lift $ P.registerGauge "process_open_fd" (popts ^. labels)
+  return RidleyMetricHandler {
+    metric = openFD
+  , updateMetric = updateOpenFD pid
+  , flush = False
+  }

--- a/ridley-extras/stack.yaml
+++ b/ridley-extras/stack.yaml
@@ -1,0 +1,16 @@
+resolver: lts-7.4
+
+packages:
+- '.'
+- '..'
+
+extra-deps:
+  - ekg-prometheus-adapter-0.1.0.3
+  - prometheus-0.4.1
+  - katip-0.3.0.0
+
+flags:
+  ridley-extras:
+    lib-Werror: true
+
+extra-package-dbs: []

--- a/ridley-extras/test/Spec.hs
+++ b/ridley-extras/test/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"

--- a/ridley.cabal
+++ b/ridley.cabal
@@ -1,5 +1,5 @@
 name:                ridley
-version:             0.3.0.0
+version:             0.3.1.0
 synopsis:            Quick metrics to grow you app strong.
 description:         Please see README.md
 homepage:            https://github.com/iconnect/ridley#readme
@@ -46,6 +46,7 @@ library
                        microlens,
                        microlens-th,
                        process,
+                       string-conv,
                        ekg-prometheus-adapter >= 0.1.0.3,
                        inline-c,
                        vector,

--- a/src/System/Metrics/Prometheus/Ridley.hs
+++ b/src/System/Metrics/Prometheus/Ridley.hs
@@ -32,8 +32,10 @@ import           Control.Monad.Trans.Class (lift)
 import           Data.IORef
 import qualified Data.List as List
 import           Data.Map.Strict as M
+import           Data.Monoid ((<>))
 import qualified Data.Set as Set
 import           Data.String
+import qualified Data.Text as T
 import           Data.Time
 import           GHC.Conc (getNumCapabilities, getNumProcessors)
 import           Katip
@@ -68,6 +70,9 @@ registerMetrics (x:xs) = do
   let popts = opts ^. prometheusOptions
   let sev   = opts ^. katipSeverity
   case x of
+    CustomMetric metricName custom -> do
+      $(logTM) sev $ "Registering CustomMetric '" <> fromString (T.unpack metricName) <> "'..."
+      (custom :) <$> (registerMetrics xs)
     ProcessMemory -> do
       processReservedMemory <- lift $ P.registerGauge "process_memory_kb" (popts ^. labels)
       let !m = processMemory processReservedMemory

--- a/src/System/Metrics/Prometheus/Ridley.hs
+++ b/src/System/Metrics/Prometheus/Ridley.hs
@@ -71,8 +71,9 @@ registerMetrics (x:xs) = do
   let sev   = opts ^. katipSeverity
   case x of
     CustomMetric metricName custom -> do
+      customMetric <- lift (custom opts)
       $(logTM) sev $ "Registering CustomMetric '" <> fromString (T.unpack metricName) <> "'..."
-      (custom :) <$> (registerMetrics xs)
+      (customMetric :) <$> (registerMetrics xs)
     ProcessMemory -> do
       processReservedMemory <- lift $ P.registerGauge "process_memory_kb" (popts ^. labels)
       let !m = processMemory processReservedMemory

--- a/src/System/Metrics/Prometheus/Ridley/Types.hs
+++ b/src/System/Metrics/Prometheus/Ridley/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -63,7 +64,7 @@ data RidleyMetric = ProcessMemory
                   | Wai
                   | DiskUsage
                   -- ^ Gets stats about Disk usage (free space, etc)
-                  | CustomMetric T.Text RidleyMetricHandler
+                  | CustomMetric T.Text (forall m. MonadIO m => RidleyOptions -> P.RegistryT m RidleyMetricHandler)
                   -- ^ A user-defined metric, identified by a name.
 
 instance Show RidleyMetric where


### PR DESCRIPTION
This PR adds a `CustomMetric` constructor to the `RidleyMetric` ADT, which allows user to pass externally-defined handlers to be sampled with Ridley.

I have also created an impromptu `ridley-extras` package to store a set of predefined metrics users might be interested in.