### PR TITLE
Update to compile also with newer katip, etc. (fixes #12)

### DIFF
--- a/ridley-extras/ridley-extras.cabal
+++ b/ridley-extras/ridley-extras.cabal
@@ -23,8 +23,8 @@ library
   exposed-modules:     System.Metrics.Prometheus.Ridley.Metrics.FD
   build-depends:       base >= 4.7 && < 5,
                        text,
-                       prometheus < 0.5.0.0,
-                       shelly < 1.7.0.0,
+                       prometheus < 3,
+                       shelly < 1.9.0.0,
                        microlens,
                        ekg-prometheus-adapter < 0.2.0.0,
                        mtl,

--- a/ridley-extras/ridley-extras.cabal
+++ b/ridley-extras/ridley-extras.cabal
@@ -1,5 +1,5 @@
 name:                ridley-extras
-version:             0.1.0.1
+version:             0.1.0.2
 synopsis:            Handy metrics that don't belong to ridley.
 description:         See README.md
 homepage:            https://github.com/iconnect/ridley/ridley-extras#readme

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -1,5 +1,5 @@
 name:                ridley
-version:             0.3.1.2
+version:             0.3.1.3
 synopsis:            Quick metrics to grow your app strong.
 description:         Please see README.md
 homepage:            https://github.com/iconnect/ridley#README

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -32,8 +32,8 @@ library
 
   build-depends:       async < 3.0.0,
                        base >= 4.7 && < 5,
-                       containers < 0.6.0.0,
-                       katip < 0.4.0.0,
+                       containers < 0.7.0.0,
+                       katip < 0.8.0.0,
                        wai-middleware-metrics < 0.3.0.0,
                        template-haskell,
                        ekg-core,


### PR DESCRIPTION
This compiles with a GHC 8.4.4-based package stack. Let's see if CI shows that the ifdefs are enough to keep it compiling with older packages.