### PR TITLE
Prepare for Hackage release

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc:  ['8.6.5', '8.8.4','8.10.2']
+        ghc:  ['8.6.5', '8.8.4','8.10.2', '8.10.3']
         cabal: ['3.2.0.0']
 
         os: [ubuntu-latest]
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         stack: ["2.3.1"]
-        ghc: ["8.6.5", "8.8.4", "8.10.2"]
+        ghc: ["8.6.5", "8.8.4", "8.10.2", "8.10.3"]
 
     steps:
     - uses: actions/checkout@v2

--- a/ridley-extras/ridley-extras.cabal
+++ b/ridley-extras/ridley-extras.cabal
@@ -1,5 +1,5 @@
 name:                ridley-extras
-version:             0.1.0.2
+version:             0.1.1.0
 synopsis:            Handy metrics that don't belong to ridley.
 description:         See README.md
 homepage:            https://github.com/iconnect/ridley/ridley-extras#readme

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -1,5 +1,5 @@
 name:                ridley
-version:             0.3.1.5
+version:             0.3.2.0
 synopsis:            Quick metrics to grow your app strong.
 description:         Please see README.md
 homepage:            https://github.com/iconnect/ridley#README

--- a/stack-8.10.3.yaml
+++ b/stack-8.10.3.yaml
@@ -1,0 +1,14 @@
+resolver: lts-17.2
+install-ghc: true
+allow-newer: true
+flags: {}
+packages:
+- 'ridley'
+- 'ridley-extras'
+system-ghc: false
+extra-deps:
+- ekg-prometheus-adapter-0.1.0.4
+- katip-0.7.0.0
+- prometheus-2.1.3
+- unliftio-core-0.1.2.0
+- wai-middleware-metrics-0.2.4

--- a/stack-8.10.4.yaml
+++ b/stack-8.10.4.yaml
@@ -1,0 +1,14 @@
+resolver: lts-17.5
+install-ghc: true
+allow-newer: true
+flags: {}
+packages:
+- 'ridley'
+- 'ridley-extras'
+system-ghc: false
+extra-deps:
+- ekg-prometheus-adapter-0.1.0.4
+- katip-0.7.0.0
+- prometheus-2.1.3
+- unliftio-core-0.1.2.0
+- wai-middleware-metrics-0.2.4


### PR DESCRIPTION
Fixes #24. 

As I was at it, apart from bumping the package versions, I have added support for building with GHC 8.10.4.