### PR TITLE
Per-metric update timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ ridley-extras/dist
 tags
 dist-newstyle
 hie.yaml
+cabal.project.local

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ example/Main.o
 ridley-extras/dist
 tags
 dist-newstyle
+hie.yaml

--- a/cabal.project
+++ b/cabal.project
@@ -2,6 +2,6 @@ packages: ridley
           ridley-extras
 
 allow-newer:
-  katip:time,template-haskell
-  prometheus:base
+  katip:time,template-haskell,
+  prometheus:base,
   unliftio-core:base

--- a/ridley/example/Main.hs
+++ b/ridley/example/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE CPP #-}
 import           System.Metrics.Prometheus.Ridley
 import qualified System.Metrics.Prometheus.Metric.Gauge as P
@@ -30,7 +31,7 @@ app ctx = do
 
 customExpensiveMetric :: RidleyMetric
 customExpensiveMetric =
-  CustomMetric "my-expensive" (Just 60) get_metric
+  CustomMetric "my-expensive" (Just $ 60 * 1_000_000) get_metric
   where
     get_metric :: MonadIO m => RidleyOptions -> P.RegistryT m RidleyMetricHandler
     get_metric opts = do

--- a/ridley/example/Main.hs
+++ b/ridley/example/Main.hs
@@ -1,11 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 import           System.Metrics.Prometheus.Ridley
+import qualified System.Metrics.Prometheus.Metric.Gauge as P
+import qualified System.Metrics.Prometheus.RegistryT as P
+import           System.Metrics.Prometheus.Ridley.Types
 import           Lens.Micro
 import           Web.Spock
 import           Web.Spock.Config
 import           Network.Wai.Metrics
 import           Control.Monad.Trans
 import           Data.Monoid
+import           Data.Time.Clock.POSIX
 import           Data.IORef
 import           Katip
 import           System.IO
@@ -23,11 +28,33 @@ app ctx = do
   get root $ text "Hello World!"
   get "ping" $ text "pong"
 
+customExpensiveMetric :: RidleyMetric
+customExpensiveMetric =
+  CustomMetric "my-expensive" (Just 60) get_metric
+  where
+    get_metric :: MonadIO m => RidleyOptions -> P.RegistryT m RidleyMetricHandler
+    get_metric opts = do
+        m <- P.registerGauge "current_time" (opts ^. prometheusOptions . labels)
+        return RidleyMetricHandler { metric = m, updateMetric = update, flush = False }
+
+    update :: P.Gauge -> Bool -> IO ()
+    update gauge _ = do n  <- getPOSIXTime
+                        tn <- getCurrentTime
+                        putStrLn $ "Updating time, at " <> show tn
+                        P.set (realToFrac n) gauge
+
 main :: IO ()
 main = do
-    stdoutS <- mkHandleScribe ColorIfTerminal stdout InfoS V2
-    let opts = newOptions [("service", "ridley-test")] defaultMetrics
+#if MIN_VERSION_katip(0,8,0)
+    let onlyErrors i = pure $ Katip._itemSeverity i >= Katip.ErrorS
+    ridleyScribe <-
+      Katip.mkHandleScribe Katip.ColorIfTerminal stdout onlyErrors Katip.V2
+#else
+    ridleyScribe <-
+      Katip.mkHandleScribe Katip.ColorIfTerminal stdout Katip.ErrorS Katip.V2
+#endif
+    let opts = newOptions [("service", "ridley-test")] (customExpensiveMetric : defaultMetrics)
              & prometheusOptions . samplingFrequency .~ 5
              & dataRetentionPeriod .~ Just 60
-             & katipScribes .~ ("RidleyTest", [("stdout", stdoutS)])
+             & katipScribes .~ ("RidleyTest", [("stdout", ridleyScribe)])
     startRidley opts ["metrics"] 8729 >>= spockWeb

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -31,6 +31,7 @@ library
                        System.Metrics.Prometheus.Ridley.Metrics.Network.Types
 
   build-depends:       async < 3.0.0,
+                       auto-update >= 0.1,
                        base >= 4.7 && < 5,
                        containers < 0.7.0.0,
                        katip < 0.9.0.0,

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -44,7 +44,7 @@ library
                        template-haskell,
                        ekg-core,
                        time,
-                       text,
+                       text >= 1.2.4.0,
                        mtl,
                        shelly,
                        transformers,

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -1,5 +1,5 @@
 name:                ridley
-version:             0.3.2.1
+version:             0.3.3.0
 synopsis:            Quick metrics to grow your app strong.
 description:         Please see README.md
 homepage:            https://github.com/iconnect/ridley#README
@@ -18,6 +18,11 @@ flag lib-Werror
      manual: True
      default: False
      description: Enable -Werror
+
+flag library-only
+  description: Build without the executable, for downstream packages
+  manual: True
+  default: True
 
 library
   hs-source-dirs:      src
@@ -86,6 +91,22 @@ test-suite ridley-test
                      , http-client >= 0.4.30
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
+
+executable ridley-example
+    main-is: example/Main.hs
+    if !flag(library-only)
+      build-depends: base
+                   , time
+                   , ridley
+                   , katip
+                   , text
+                   , wai-middleware-metrics
+                   , Spock
+                   , microlens
+                   , mtl
+                   , prometheus
+    if flag(library-only)
+      buildable: False
 
 source-repository head
   type:     git

--- a/ridley/src/System/Metrics/Prometheus/Ridley.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley.hs
@@ -80,11 +80,11 @@ registerMetrics (x:xs) = do
     CustomMetric metricName mb_timeout custom -> do
       customMetric <- case mb_timeout of
         Nothing   -> lift (custom opts)
-        Just secs -> do
+        Just microseconds -> do
           RidleyMetricHandler mtr upd flsh <- lift (custom opts)
           doUpdate <- liftIO $ Auto.mkAutoUpdate Auto.defaultUpdateSettings
                         { updateAction = upd mtr flsh
-                        , updateFreq   = secs * 1_000_000
+                        , updateFreq   = microseconds
                         }
           pure $ RidleyMetricHandler mtr (\_ _ -> doUpdate) flsh
       $(logTM) sev $ "Registering CustomMetric '" <> fromString (T.unpack metricName) <> "'..."

--- a/ridley/src/System/Metrics/Prometheus/Ridley.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE CPP #-}
 module System.Metrics.Prometheus.Ridley (
     startRidley
@@ -22,6 +23,7 @@ module System.Metrics.Prometheus.Ridley (
   , defaultMetrics
   ) where
 
+import           Control.AutoUpdate as Auto
 import           Control.Concurrent (threadDelay, forkIO)
 import           Control.Concurrent.Async
 import           Control.Concurrent.MVar
@@ -75,8 +77,16 @@ registerMetrics (x:xs) = do
   let popts = opts ^. prometheusOptions
   let sev   = opts ^. katipSeverity
   case x of
-    CustomMetric metricName custom -> do
-      customMetric <- lift (custom opts)
+    CustomMetric metricName mb_timeout custom -> do
+      customMetric <- case mb_timeout of
+        Nothing   -> lift (custom opts)
+        Just secs -> do
+          RidleyMetricHandler mtr upd flsh <- lift (custom opts)
+          doUpdate <- liftIO $ Auto.mkAutoUpdate Auto.defaultUpdateSettings
+                        { updateAction = upd mtr flsh
+                        , updateFreq   = secs * 1_000_000
+                        }
+          pure $ RidleyMetricHandler mtr (\_ _ -> doUpdate) flsh
       $(logTM) sev $ "Registering CustomMetric '" <> fromString (T.unpack metricName) <> "'..."
       (customMetric :) <$> (registerMetrics xs)
     ProcessMemory -> do

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Types.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Types.hs
@@ -67,7 +67,7 @@ data RidleyMetric = ProcessMemory
                   | CustomMetric !T.Text
                                  -- ^ The name of the metric
                                  !(Maybe Int)
-                                 -- ^ An optional timeout, in seconds,
+                                 -- ^ An optional timeout, in microseconds,
                                  -- that regulates how often the metric is
                                  -- actually updated. If Nothing, the metric
                                  -- will be updated using Ridley top-level setting,

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Types.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Types.hs
@@ -64,7 +64,17 @@ data RidleyMetric = ProcessMemory
                   | Wai
                   | DiskUsage
                   -- ^ Gets stats about Disk usage (free space, etc)
-                  | CustomMetric T.Text (forall m. MonadIO m => RidleyOptions -> P.RegistryT m RidleyMetricHandler)
+                  | CustomMetric !T.Text
+                                 -- ^ The name of the metric
+                                 !(Maybe Int)
+                                 -- ^ An optional timeout, in seconds,
+                                 -- that regulates how often the metric is
+                                 -- actually updated. If Nothing, the metric
+                                 -- will be updated using Ridley top-level setting,
+                                 -- if 'Just' the underlying 'IO' action will be run
+                                 -- only every @n@ seconds, or cached otherwise.
+                                 (forall m. MonadIO m => RidleyOptions -> P.RegistryT m RidleyMetricHandler)
+                                 -- ^ An action to generate the handler.
                   -- ^ A user-defined metric, identified by a name.
 
 instance Show RidleyMetric where
@@ -74,7 +84,7 @@ instance Show RidleyMetric where
   show Network               = "Network"
   show Wai                   = "Wai"
   show DiskUsage             = "DiskUsage"
-  show (CustomMetric name _) = "Custom@" <> T.unpack name
+  show (CustomMetric name _ _) = "Custom@" <> T.unpack name
 
 instance Eq RidleyMetric where
   (==) ProcessMemory ProcessMemory             = True
@@ -83,7 +93,7 @@ instance Eq RidleyMetric where
   (==) Network Network                         = True
   (==) Wai     Wai                             = True
   (==) DiskUsage DiskUsage                     = True
-  (==) (CustomMetric n1 _) (CustomMetric n2 _) = (==) n1 n2
+  (==) (CustomMetric n1 _ _) (CustomMetric n2 _ _) = (==) n1 n2
   (==) _ _                                     = False
 
 instance Ord RidleyMetric where
@@ -120,14 +130,14 @@ instance Ord RidleyMetric where
     Wai                    -> LT
     DiskUsage              -> EQ
     _                      -> GT
-  compare (CustomMetric n1 _) xs = case xs of
+  compare (CustomMetric n1 _ _) xs = case xs of
     ProcessMemory          -> LT
     CPULoad                -> LT
     GHCConc                -> LT
     Network                -> LT
     Wai                    -> LT
     DiskUsage              -> LT
-    (CustomMetric n2 _)    -> compare n1 n2
+    (CustomMetric n2 _ _)    -> compare n1 n2
 
 --------------------------------------------------------------------------------
 data RidleyOptions = RidleyOptions {


### PR DESCRIPTION
Fixes #28. I have opted to keep things simple, and now we have a new parameter for the `CustomMetric` constructor, which, if `Just`, will leverage the excellent `auto-update` library to execute actions efficiently every `n` seconds:

<img width="515" alt="Screenshot 2022-01-06 at 14 44 45" src="https://user-images.githubusercontent.com/442035/148392411-998c4671-8a17-422e-bafa-dba54d63b4d2.png">

