### PR TITLE
Allow Ridley to survive exceptions thrown by handlers

### DIFF
--- a/ridley-extras/src/System/Metrics/Prometheus/Ridley/Metrics/FD.hs
+++ b/ridley-extras/src/System/Metrics/Prometheus/Ridley/Metrics/FD.hs
@@ -52,8 +52,4 @@ processOpenFD :: MonadIO m
 processOpenFD pid opts = do
   let popts = opts ^. prometheusOptions
   openFD <- P.registerGauge "process_open_fd" (popts ^. labels)
-  return RidleyMetricHandler {
-    metric = openFD
-  , updateMetric = updateOpenFD pid
-  , flush = False
-  }
+  return $ mkRidleyMetricHandler "ridley-process-open-file-descriptors" openFD (updateOpenFD pid) False

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -34,6 +34,7 @@ library
                        System.Metrics.Prometheus.Ridley.Metrics.CPU
                        System.Metrics.Prometheus.Ridley.Metrics.Network
                        System.Metrics.Prometheus.Ridley.Metrics.Network.Types
+  other-modules:       System.Metrics.Prometheus.Ridley.Types.Internal
 
   build-depends:       async < 3.0.0,
                        auto-update >= 0.1,
@@ -47,6 +48,7 @@ library
                        text >= 1.2.4.0,
                        mtl,
                        shelly,
+                       safe-exceptions < 1.8,
                        transformers,
                        prometheus > 0.5.0 && < 2.3.0,
                        raw-strings-qq,

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/CPU/Darwin.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/CPU/Darwin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 module System.Metrics.Prometheus.Ridley.Metrics.CPU.Darwin
@@ -5,7 +6,6 @@ module System.Metrics.Prometheus.Ridley.Metrics.CPU.Darwin
   , processCPULoad
   ) where
 
-import           Data.Monoid ((<>))
 import qualified Data.Vector.Storable as V
 import qualified Data.Vector.Storable.Mutable as VM
 import           Foreign.C.Types
@@ -37,8 +37,4 @@ updateCPULoad (cpu1m, cpu5m, cpu15m) _ = do
 
 --------------------------------------------------------------------------------
 processCPULoad :: (P.Gauge, P.Gauge, P.Gauge) -> RidleyMetricHandler
-processCPULoad g = RidleyMetricHandler {
-    metric = g
-  , updateMetric = updateCPULoad
-  , flush = False
-  }
+processCPULoad g = mkRidleyMetricHandler "ridley-process-cpu-load" g updateCPULoad False

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/CPU/Unix.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/CPU/Unix.hs
@@ -43,8 +43,4 @@ updateCPULoad (cpu1m, cpu5m, cpu15m) _ = do
 
 --------------------------------------------------------------------------------
 processCPULoad :: (P.Gauge, P.Gauge, P.Gauge) -> RidleyMetricHandler
-processCPULoad g = RidleyMetricHandler {
-    metric = g
-  , updateMetric = updateCPULoad
-  , flush = False
-  }
+processCPULoad g = mkRidleyMetricHandler "ridley-process-cpu-load" g updateCPULoad False

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/DiskUsage.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/DiskUsage.hs
@@ -84,11 +84,7 @@ updateDiskUsageMetrics dmetrics flush = do
 
 --------------------------------------------------------------------------------
 diskUsageMetrics :: DiskUsageMetrics -> RidleyMetricHandler
-diskUsageMetrics g = RidleyMetricHandler {
-    metric = g
-  , updateMetric = updateDiskUsageMetrics
-  , flush = False
-  }
+diskUsageMetrics g = mkRidleyMetricHandler "ridley-disk-usage" g updateDiskUsageMetrics False
 
 --------------------------------------------------------------------------------
 mkDiskGauge :: MonadIO m => P.Labels -> DiskUsageMetrics -> DiskStats -> P.RegistryT m DiskUsageMetrics

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Memory.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Memory.hs
@@ -32,8 +32,4 @@ updateProcessMemory g _ = do
 
 --------------------------------------------------------------------------------
 processMemory :: P.Gauge -> RidleyMetricHandler
-processMemory g = RidleyMetricHandler {
-    metric = g
-  , updateMetric = updateProcessMemory
-  , flush = False
-  }
+processMemory g = mkRidleyMetricHandler "ridley-process-memory" g updateProcessMemory False

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Network/Darwin.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Network/Darwin.hs
@@ -12,7 +12,6 @@ module System.Metrics.Prometheus.Ridley.Metrics.Network.Darwin
 import           Control.Monad
 import           Control.Monad.IO.Class
 import qualified Data.Map.Strict as M
-import           Data.Monoid ((<>))
 import qualified Data.Text as T
 import           Foreign.C.String
 import           Foreign.C.Types
@@ -167,11 +166,7 @@ updateNetworkMetrics nmetrics flush = do
 
 --------------------------------------------------------------------------------
 networkMetrics :: NetworkMetrics -> RidleyMetricHandler
-networkMetrics g = RidleyMetricHandler {
-    metric = g
-  , updateMetric = updateNetworkMetrics
-  , flush = False
-  }
+networkMetrics g = mkRidleyMetricHandler "ridley-network-metrics" g updateNetworkMetrics False
 
 --------------------------------------------------------------------------------
 mkInterfaceGauge :: MonadIO m => P.Labels -> NetworkMetrics -> IfData -> P.RegistryT m NetworkMetrics

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Network/Unix.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Network/Unix.hs
@@ -70,11 +70,7 @@ updateNetworkMetrics nmetrics mustFlush = do
 
 --------------------------------------------------------------------------------
 networkMetrics :: NetworkMetrics -> RidleyMetricHandler
-networkMetrics g = RidleyMetricHandler {
-    metric = g
-  , updateMetric = updateNetworkMetrics
-  , flush = False
-  }
+networkMetrics g = mkRidleyMetricHandler "ridley-network-metrics" g updateNetworkMetrics False
 
 --------------------------------------------------------------------------------
 mkInterfaceGauge :: MonadIO m => P.Labels -> NetworkMetrics -> IfData -> P.RegistryT m NetworkMetrics

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Types/Internal.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Types/Internal.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ExistentialQuantification #-}
+module System.Metrics.Prometheus.Ridley.Types.Internal
+  ( RidleyMetricHandler(..)
+  ) where
+
+import           GHC.Stack
+import qualified Data.Text as T
+
+--------------------------------------------------------------------------------
+data RidleyMetricHandler = forall c. RidleyMetricHandler {
+  -- | An opaque metric
+    metric       :: c
+  -- | An IO action used to update the metric
+  , updateMetric :: c -> Bool -> IO ()
+  -- | Whether or not to flush this Metric
+  , flush        :: !Bool
+  -- | A user-friendly label, used to report errors
+  , label        :: !T.Text
+  -- | A CallStack, for precise error reporting
+  , _cs          :: CallStack
+  }
+


### PR DESCRIPTION
Fixes #30.

I have taken the liberty of reshuffling things around a bit, and notably we now have a new smart constructor `mkRidleyMetricHandler` which will automatically populate a `label` field with the `CallStack` in scope, so that users will get a somewhat precise information of _which_ handler errored out:

<img width="952" alt="Screenshot 2022-03-10 at 16 39 50" src="https://user-images.githubusercontent.com/442035/157697856-e860081b-ae79-4b13-b044-ff6744ed779e.png">

