### PR TITLE
Remove use of readProcess

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,6 @@ allow-newer:
   superbuffer:bytestring,
   wai-extra:wai-logger,
   wai-logger:*
+
+constraints:
+  ekg-prometheus-adapter == 0.1.0.4

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -59,7 +59,8 @@ library
                        ekg-prometheus-adapter >= 0.1.0.3,
                        inline-c,
                        vector,
-                       unix
+                       unix,
+                       unliftio-core
   c-sources:           cbits/helpers.c
   cc-options:          -Wall -std=c99
   default-language:    Haskell2010

--- a/ridley/src/System/Metrics/Prometheus/Ridley.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley.hs
@@ -116,9 +116,7 @@ registerMetrics (x:xs) = do
     -- Ignore `Wai` as we will use an external library for that.
     Wai     -> registerMetrics xs
     DiskUsage -> do
-      diskStats <- liftIO getDiskStats
-      dmap   <- lift $ foldM (mkDiskGauge (popts ^. labels)) M.empty diskStats
-      let !diskUsage = diskUsageMetrics dmap
+      diskUsage <- newDiskUsageMetrics
       $(logTM) sev "Registering DiskUsage metric..."
       (diskUsage :) <$> registerMetrics xs
     Network -> do

--- a/ridley/src/System/Metrics/Prometheus/Ridley.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley.hs
@@ -94,8 +94,9 @@ registerMetrics (x:xs) = do
       $(logTM) sev $ "Registering CustomMetric '" <> fromString (T.unpack metricName) <> "'..."
       (customMetric :) <$> (registerMetrics xs)
     ProcessMemory -> do
+      logger <- ioLogger
       processReservedMemory <- lift $ P.registerGauge "process_memory_kb" (popts ^. labels)
-      let !m = processMemory processReservedMemory
+      let !m = processMemory logger processReservedMemory
       $(logTM) sev "Registering ProcessMemory metric..."
       (m :) <$> (registerMetrics xs)
     CPULoad -> do

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/DiskUsage.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/DiskUsage.hs
@@ -3,24 +3,27 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 module System.Metrics.Prometheus.Ridley.Metrics.DiskUsage (
-    getDiskStats
-  , mkDiskGauge
-  , diskUsageMetrics
+  newDiskUsageMetrics
   ) where
 
 import           Control.Monad
 import           Control.Monad.IO.Class
-import qualified Data.Map.Strict as M
+import           Control.Monad.Trans.Class
 import           Data.Maybe
-import qualified Data.Text as T
+import           Katip
 import           Lens.Micro
 import           Lens.Micro.TH
+import           System.Exit
+import           System.Metrics.Prometheus.Ridley.Types
+import           System.Metrics.Prometheus.Ridley.Types.Internal
+import           System.Process
+import           System.Remote.Monitoring.Prometheus (labels)
+import           Text.Read hiding (lift)
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
 import qualified System.Metrics.Prometheus.Metric.Gauge as P
 import qualified System.Metrics.Prometheus.MetricId as P
 import qualified System.Metrics.Prometheus.RegistryT as P
-import           System.Metrics.Prometheus.Ridley.Types
-import           System.Process
-import           Text.Read
 
 
 --------------------------------------------------------------------------------
@@ -42,12 +45,16 @@ data DiskMetric = DiskMetric {
 type DiskUsageMetrics = M.Map T.Text DiskMetric
 
 --------------------------------------------------------------------------------
-getDiskStats :: IO [DiskStats]
-getDiskStats = do
+getDiskStats :: Logger -> IO [DiskStats]
+getDiskStats logger = do
   let diskOnly = (\d -> "/dev" `T.isInfixOf` (d ^. diskFilesystem))
-  let dropHeader = drop 1
-  rawLines <- dropHeader . T.lines . T.strip . T.pack <$> readProcess "df" [] []
-  return $ filter diskOnly . mapMaybe mkDiskStats $ rawLines
+  let dropHeader = drop 1 . T.lines . T.strip . T.pack
+  (exitCode, rawLines, errors) <- readProcessWithExitCode "df" [] []
+  case exitCode of
+    ExitSuccess    -> return $ filter diskOnly . mapMaybe mkDiskStats $ dropHeader rawLines
+    ExitFailure ec -> do
+      logger ErrorS $ "getDiskStats exited with error code " <> T.pack (show ec) <> ": " <> T.pack errors
+      pure mempty
   where
     mkDiskStats :: T.Text -> Maybe DiskStats
     mkDiskStats rawLine = case T.words rawLine of
@@ -73,18 +80,23 @@ updateDiskUsageMetric DiskMetric{..} d _ = do
   P.set (d ^. diskFree) _dskMetricFree
 
 --------------------------------------------------------------------------------
-updateDiskUsageMetrics :: DiskUsageMetrics -> Bool -> IO ()
-updateDiskUsageMetrics dmetrics flush = do
-  diskStats <- getDiskStats
+updateDiskUsageMetrics :: Logger -> DiskUsageMetrics -> Bool -> IO ()
+updateDiskUsageMetrics logger dmetrics flush = do
+  diskStats <- getDiskStats logger
   forM_ diskStats $ \d -> do
     let key = d ^. diskFilesystem
     case M.lookup key dmetrics of
       Nothing -> return ()
       Just m  -> updateDiskUsageMetric m d flush
 
---------------------------------------------------------------------------------
-diskUsageMetrics :: DiskUsageMetrics -> RidleyMetricHandler
-diskUsageMetrics g = mkRidleyMetricHandler "ridley-disk-usage" g updateDiskUsageMetrics False
+-- | Creates a new 'RidleyMetricHandler' to monitor disk usage.
+newDiskUsageMetrics :: Ridley RidleyMetricHandler
+newDiskUsageMetrics = do
+  logger <- ioLogger
+  opts <- getRidleyOptions
+  diskStats <- liftIO (getDiskStats logger)
+  metrics   <- lift $ foldM (mkDiskGauge (opts ^. prometheusOptions . labels)) M.empty diskStats
+  pure $ mkRidleyMetricHandler "ridley-disk-usage" metrics (updateDiskUsageMetrics logger) False
 
 --------------------------------------------------------------------------------
 mkDiskGauge :: MonadIO m => P.Labels -> DiskUsageMetrics -> DiskStats -> P.RegistryT m DiskUsageMetrics

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Memory.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Metrics/Memory.hs
@@ -3,11 +3,15 @@ module System.Metrics.Prometheus.Ridley.Metrics.Memory (
     processMemory
   ) where
 
-import qualified System.Metrics.Prometheus.Metric.Gauge as P
+import           Katip
+import           System.Exit
 import           System.Metrics.Prometheus.Ridley.Types
+import           System.Metrics.Prometheus.Ridley.Types.Internal
 import           System.Posix.Process
 import           System.Process
 import           Text.Read
+import qualified Data.Text as T
+import qualified System.Metrics.Prometheus.Metric.Gauge as P
 
 --------------------------------------------------------------------------------
 -- | Return the amount of occupied memory for this
@@ -16,20 +20,26 @@ import           Text.Read
 -- accurate, at least works on Darwin and Linux
 -- without using any CPP processor.
 -- Returns the memory in Kb.
-getProcessMemory :: IO (Maybe Integer)
-getProcessMemory = do
+getProcessMemory :: Logger -> IO (Maybe Integer)
+getProcessMemory logger = do
   myPid <- getProcessID
-  readMaybe <$> readProcess "ps" ["-o", "rss=", "-p", show myPid] []
+  (exitCode, rawOutput, errors) <- readProcessWithExitCode "ps" ["-o", "rss=", "-p", show myPid] []
+  case exitCode of
+    ExitSuccess    -> pure $ readMaybe rawOutput
+    ExitFailure ec -> do
+      logger ErrorS $ "getProcessMemory exited with error code " <> T.pack (show ec) <> ": " <> T.pack errors
+      pure Nothing
 
 --------------------------------------------------------------------------------
 -- | As this is a gauge, it makes no sense flushing it.
-updateProcessMemory :: P.Gauge -> Bool -> IO ()
-updateProcessMemory g _ = do
-  mbMem <- getProcessMemory
+updateProcessMemory :: Logger -> P.Gauge -> Bool -> IO ()
+updateProcessMemory logger g _ = do
+  mbMem <- getProcessMemory logger
   case mbMem of
     Nothing -> return ()
     Just m  -> P.set (fromIntegral m) g
 
 --------------------------------------------------------------------------------
-processMemory :: P.Gauge -> RidleyMetricHandler
-processMemory g = mkRidleyMetricHandler "ridley-process-memory" g updateProcessMemory False
+processMemory :: Logger -> P.Gauge -> RidleyMetricHandler
+processMemory logger g = do
+  mkRidleyMetricHandler "ridley-process-memory" g (updateProcessMemory logger) False

--- a/ridley/src/System/Metrics/Prometheus/Ridley/Types/Internal.hs
+++ b/ridley/src/System/Metrics/Prometheus/Ridley/Types/Internal.hs
@@ -2,8 +2,10 @@
 {-# LANGUAGE ExistentialQuantification #-}
 module System.Metrics.Prometheus.Ridley.Types.Internal
   ( RidleyMetricHandler(..)
+  , Logger
   ) where
 
+import           Katip
 import           GHC.Stack
 import qualified Data.Text as T
 
@@ -21,3 +23,4 @@ data RidleyMetricHandler = forall c. RidleyMetricHandler {
   , _cs          :: CallStack
   }
 
+type Logger = Severity -> T.Text -> IO ()


### PR DESCRIPTION
Fixes #39. This PR replaces occurrences of `readProcess` with `readProcessWithExitCode`. In case of failures, the stderr is logged, but the overall ridley process is not aborted.