### PR TITLE
Make registering handlers resilient to synchronous exceptions

### DIFF
--- a/ridley/example/run_example.sh
+++ b/ridley/example/run_example.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-stack runghc --package Spock Main.hs
+cabal v2-run ridley-example

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -44,6 +44,7 @@ library
                        wai-middleware-metrics < 0.3.0.0,
                        template-haskell,
                        ekg-core,
+                       exceptions < 0.11,
                        time,
                        text >= 1.2.4.0,
                        mtl,


### PR DESCRIPTION
Fixes #40.

This PR refactors `registerMetrics` by wrapping each handler's registration function with a `tryRegister` combinator which will catch synchronous exception which might be raised during registration, avoiding that a single failed registration causes the whole `ridley` thread to abort.

It's slightly unsatisfactory that the `Wai` case is a bit of an outlier there, but fixing that would require (I suspect), some more thorough refactoring. I wonder if I should just remove `Wai` data constructor and simply implement it as a `CustomMetric`, which might be better here. See also #23 .