### PR TITLE
Bump version, add changelog

### DIFF
--- a/ridley/ChangeLog.md
+++ b/ridley/ChangeLog.md
@@ -1,0 +1,7 @@
+
+# 0.3.4.0
+
+* Remove use of `readProcess` for some handlers ([#41](https://github.com/iconnect/ridley/pull/41)).
+* Make `getDiskStats`, `mkDiskGauge` internal functions ([#41](https://github.com/iconnect/ridley/pull/41)).
+* Rename `diskUsageMetrics` to `newDiskUsageMetrics` (([#41](https://github.com/iconnect/ridley/pull/41))).
+* Make `registerMetrics` resilient to synchronous exceptions (([#42](https://github.com/iconnect/ridley/pull/42)))

--- a/ridley/ridley.cabal
+++ b/ridley/ridley.cabal
@@ -1,5 +1,5 @@
 name:                ridley
-version:             0.3.3.1
+version:             0.3.4.0
 synopsis:            Quick metrics to grow your app strong.
 description:         A collection of Prometheus metrics to monitor your app. Please see README.md
 homepage:            https://github.com/iconnect/ridley#README


### PR DESCRIPTION
Fixes #43. I have dumped the version of ridley to `0.3.4.0` and added a changelog (better later than never!)