### PR TITLE
Add GHC 9.10.2 & update Prometheus dependency

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -170,6 +170,7 @@ jobs:
           echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
           cat >> cabal.project <<EOF
           constraints: ekg-prometheus-adapter == 0.1.0.5
+          constraints: katip <0.8.8.3 || >0.8.8.3
           allow-newer: katip:time
           allow-newer: template-haskell
           allow-newer: prometheus:base

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.2
+            compilerKind: ghc
+            compilerVersion: 9.10.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.6.6
             compilerKind: ghc
             compilerVersion: 9.6.6

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250216
+# version: 0.19.20250722
 #
-# REGENDATA ("0.19.20250216",["github","cabal.project"])
+# REGENDATA ("0.19.20250722",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -52,12 +52,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -158,7 +158,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_ridley}" >> cabal.project
           echo "package ridley" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          echo "package ridley" >> cabal.project
+          echo "    ghc-options: -Werror=unused-packages" >> cabal.project
+          echo "package ridley" >> cabal.project
+          echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project
           cat >> cabal.project <<EOF
           constraints: ekg-prometheus-adapter == 0.1.0.5
           allow-newer: katip:time

--- a/cabal.project
+++ b/cabal.project
@@ -12,4 +12,8 @@ allow-newer:
   wai-logger:*
 
 constraints:
-  ekg-prometheus-adapter == 0.1.0.5
+  ekg-prometheus-adapter == 0.1.0.5,
+
+  -- katip 0.8.8.3 does not build with GHC 9.6 or below.
+  -- See: https://github.com/Soostone/katip/pull/160
+  katip <0.8.8.3 || >0.8.8.3,

--- a/ridley.cabal
+++ b/ridley.cabal
@@ -64,13 +64,15 @@ library
                        safe-exceptions < 1.8,
                        transformers,
                        prometheus > 0.5.0 && < 2.4.0,
-                       raw-strings-qq,
                        microlens,
                        microlens-th,
                        process,
                        ekg-prometheus-adapter >= 0.1.0.5,
                        inline-c,
                        vector,
+                       unix
+  if os(darwin)
+      build-depends:   raw-strings-qq
   include-dirs:        cbits
   c-sources:           cbits/helpers.c
   cc-options:          -Wall -std=c99

--- a/ridley.cabal
+++ b/ridley.cabal
@@ -68,12 +68,9 @@ library
                        microlens,
                        microlens-th,
                        process,
-                       string-conv,
                        ekg-prometheus-adapter >= 0.1.0.5,
                        inline-c,
                        vector,
-                       unix,
-                       unliftio-core
   include-dirs:        cbits
   c-sources:           cbits/helpers.c
   cc-options:          -Wall -std=c99

--- a/ridley.cabal
+++ b/ridley.cabal
@@ -63,7 +63,7 @@ library
                        shelly >= 1.8.2,
                        safe-exceptions < 1.8,
                        transformers,
-                       prometheus > 0.5.0 && < 2.3.0,
+                       prometheus > 0.5.0 && < 2.4.0,
                        raw-strings-qq,
                        microlens,
                        microlens-th,

--- a/ridley.cabal
+++ b/ridley.cabal
@@ -11,7 +11,7 @@ copyright:           2024 IRIS Connect Ltd.
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 9.4.7 || == 9.4.8 || == 9.6.6
+tested-with:         GHC == 9.4.7 || == 9.4.8 || == 9.6.6 || == 9.10.2
 
 extra-source-files:
   cbits/helpers.c

--- a/ridley.cabal
+++ b/ridley.cabal
@@ -89,7 +89,6 @@ test-suite ridley-test
                      , ridley
                      , tasty
                      , tasty-hunit
-                     , tasty-quickcheck
                      , ekg-core
                      , prometheus
                      , containers


### PR DESCRIPTION
This adds GHC 9.10.2 to `tested-with` and the CI matrix, and updates the `prometheus` dependency to allow 2.3.0.

Are there other GHC versions we also want to add, while here?