### PR TITLE
Remove spurious debug lines

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -206,7 +206,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=streaming
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: cabal check
         run: |
           cd ${PKGDIR_ridley} || false

--- a/src/System/Metrics/Prometheus/Ridley.hs
+++ b/src/System/Metrics/Prometheus/Ridley.hs
@@ -173,10 +173,6 @@ registerNetworkMetric = do
   ifaces <- liftIO getNetworkMetrics
   imap   <- lift $ foldM (mkInterfaceGauge (popts ^. labels)) M.empty ifaces
 #endif
-  -- Log diagnostic information about network interfaces (using ErrorS to ensure visibility in CI)
-  $(logTM) ErrorS $ ls $ "Network metrics: Found " <> T.pack (show (length ifaces)) <> " interfaces"
-  when (List.null ifaces) $ do
-    $(logTM) ErrorS "Network metrics: No network interfaces found - metrics will be empty (common in containerized environments)"
   let !network = networkMetrics imap
   $(logTM) sev "Registering Network metric..."
   pure network

--- a/src/System/Metrics/Prometheus/Ridley/Metrics/Network/Unix.hs
+++ b/src/System/Metrics/Prometheus/Ridley/Metrics/Network/Unix.hs
@@ -25,20 +25,8 @@ import           System.Metrics.Prometheus.Ridley.Types
 -- | Parse /proc/net/dev to get the relevant stats.
 getNetworkMetrics :: IO [IfData]
 getNetworkMetrics = do
-  rawContent <- T.readFile "/proc/net/dev"
-  let allLines = T.lines . T.strip $ rawContent
-  let interfaces = drop 2 allLines
-  let parsed = mapMaybe mkInterface interfaces
-  
-  -- Debug logging for CI troubleshooting (using stderr for visibility)
-  IO.hPutStrLn IO.stderr $ "[DEBUG] Network metrics: /proc/net/dev has " <> show (length allLines) <> " total lines"
-  IO.hPutStrLn IO.stderr $ "[DEBUG] Network metrics: After dropping header, " <> show (length interfaces) <> " interface lines to parse"
-  IO.hPutStrLn IO.stderr $ "[DEBUG] Network metrics: Successfully parsed " <> show (length parsed) <> " interfaces"
-  when (null parsed) $ do
-    IO.hPutStrLn IO.stderr "[DEBUG] Network metrics: No interfaces parsed! Raw /proc/net/dev content:"
-    IO.hPutStrLn IO.stderr $ T.unpack rawContent
-  
-  return $! parsed
+  interfaces <- drop 2 . T.lines . T.strip <$> T.readFile "/proc/net/dev"
+  return $! mapMaybe mkInterface interfaces
   where
     mkInterface :: T.Text -> Maybe IfData
     mkInterface rawLine = case T.words . T.strip $ rawLine of


### PR DESCRIPTION
They were added to investigate CI test failures, but somehow managed to remain into the codebase.